### PR TITLE
Add an even higher-level API for people operating with full-octet streams

### DIFF
--- a/src/decode_impl.rs
+++ b/src/decode_impl.rs
@@ -259,11 +259,38 @@ pub fn decode(input: &str, output: &mut Vec<u8>, bits: u64) -> Result<(), ZBase3
     Ok(())
 }
 
+/// Decode a slice of characters to a [`Vec`] of octets (bytes).
+///
+/// It decodes to the longest full octet string, and fails if any
+/// left-over bits from the encoded form are non-zero.
+///
+/// This method is not available in `no_std` mode.
+#[cfg(feature = "std")]
+pub fn decode_full_bytes(input: &str) -> Result<Vec<u8>, ZBase32Error> {
+    let bits:u64 = ((input.len() as u64 *5)/8)*8;
+    let mut output:Vec<u8> = Vec::new();
+    match decode(input, &mut output, bits) {
+        Ok(_) => Ok(output),
+        Err(e) => Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "std")]
     use super::decode;
+    #[cfg(feature = "std")]
+    use super::decode_full_bytes;
     use crate::test_data::{TestCase, RANDOM_TEST_DATA, STANDARD_TEST_DATA};
+
+    #[cfg(feature = "std")]
+    fn run_full_bytes_tests(test_cases: &[TestCase]) {
+        for test in test_cases {
+            if (test.bits % 8) == 0 {
+                assert_eq!(test.unencoded, decode_full_bytes(test.encoded).unwrap());
+            }
+        }
+    }
 
     #[cfg(feature = "std")]
     fn run_tests(test_cases: &[TestCase]) {
@@ -285,5 +312,17 @@ mod tests {
     #[cfg(feature = "std")]
     fn test_decode_random() {
         run_tests(RANDOM_TEST_DATA);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_decode_full_bytes_standard() {
+        run_full_bytes_tests(STANDARD_TEST_DATA);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_decode_full_bytes_random() {
+        run_full_bytes_tests(RANDOM_TEST_DATA);
     }
 }

--- a/src/decode_impl.rs
+++ b/src/decode_impl.rs
@@ -261,9 +261,11 @@ pub fn decode(input: &str, output: &mut Vec<u8>, bits: u64) -> Result<(), ZBase3
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     use super::decode;
     use crate::test_data::{TestCase, RANDOM_TEST_DATA, STANDARD_TEST_DATA};
 
+    #[cfg(feature = "std")]
     fn run_tests(test_cases: &[TestCase]) {
         let mut buffer = Vec::new();
         for test in test_cases {
@@ -274,11 +276,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_decode_standard() {
         run_tests(STANDARD_TEST_DATA);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_decode_random() {
         run_tests(RANDOM_TEST_DATA);
     }

--- a/src/encode_impl.rs
+++ b/src/encode_impl.rs
@@ -250,9 +250,11 @@ pub fn encode(input: &[u8], output: &mut String, bits: u64) -> Result<(), ZBase3
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     use super::encode;
     use crate::test_data::{TestCase, RANDOM_TEST_DATA, STANDARD_TEST_DATA};
 
+    #[cfg(feature = "std")]
     fn run_tests(test_cases: &[TestCase]) {
         let mut buffer = String::new();
         for test in test_cases {
@@ -263,11 +265,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_encode_standard() {
         run_tests(STANDARD_TEST_DATA);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_encode_random() {
         run_tests(RANDOM_TEST_DATA);
     }

--- a/src/encode_impl.rs
+++ b/src/encode_impl.rs
@@ -248,12 +248,37 @@ pub fn encode(input: &[u8], output: &mut String, bits: u64) -> Result<(), ZBase3
     Ok(())
 }
 
+/// Encode a whole number of octets (bytes) to a [`String`].
+///
+/// If you need a number of bits that is not a multiple of 8 (that is,
+/// not a whole number of bytes), or you need to append to an existing
+/// string, use [`encode`] instead.
+///
+/// This method is not available in `no_std` mode.
+#[cfg(feature = "std")]
+pub fn encode_full_bytes(input: &[u8]) -> String {
+    let mut output = String::from("");
+    encode(input, &mut output, input.len() as u64 * 8).unwrap();
+    output
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "std")]
     use super::encode;
+    #[cfg(feature = "std")]
+    use super::encode_full_bytes;
     use crate::test_data::{TestCase, RANDOM_TEST_DATA, STANDARD_TEST_DATA};
 
+    #[cfg(feature = "std")]
+    fn run_full_bytes_tests(test_cases: &[TestCase]) {
+        for test in test_cases {
+            if (test.bits % 8) == 0 {
+                assert_eq!(String::from(test.encoded), encode_full_bytes(test.unencoded));
+            }
+        }
+    }
+    
     #[cfg(feature = "std")]
     fn run_tests(test_cases: &[TestCase]) {
         let mut buffer = String::new();
@@ -274,5 +299,17 @@ mod tests {
     #[cfg(feature = "std")]
     fn test_encode_random() {
         run_tests(RANDOM_TEST_DATA);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_encode_full_bytes_standard() {
+        run_full_bytes_tests(STANDARD_TEST_DATA);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_encode_full_bytes_random() {
+        run_full_bytes_tests(RANDOM_TEST_DATA);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,13 +51,14 @@
 //! ## High-level API
 //!
 //! The high-level API consists of two encoding functions
-//! [`encode_full_bytes`] and [`encode`]; and a decoding function
-//! [`decode`].
+//! [`encode_full_bytes`] and [`encode`]; and two decoding functions
+//! [`decode_full_bytes`] and [`decode`].
 //!
-//! [`encode_full_bytes`] is simple to use when you know that you have
-//! a whole number of bytes to encode and you want to produce a new
-//! String.  [`encode`] can handle numbers of bits that are not
-//! divisible by 8, and can also append to an existing String.
+//! [`encode_full_bytes`] and [`decode_full_bytes`] are simple to use
+//! when you know that the unencoded bytestring is a whole number of
+//! bytes.  [`encode`] and [`decode`] can also handle numbers of
+//! unencoded bits that are not divisible by 8, and can also append
+//! their results to existing variables.
 //!
 //! Example:
 //!
@@ -69,6 +70,9 @@
 //!
 //! let full_bytes_encoded = encode_full_bytes(DATA);
 //! assert_eq!(&full_bytes_encoded, "yysdxyy");
+//!
+//! let full_bytes_decoded = decode_full_bytes(full_bytes_encoded);
+//! assert_eq!(&full_bytes_decoded, DATA);
 //!
 //! let mut encoded = String::new();
 //! encode(DATA, &mut encoded, 25).expect("Encoding failed!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,16 +50,25 @@
 //!
 //! ## High-level API
 //!
-//! The high-level API consists of the functions [`encode`] and
-//! its reverse, [`decode`].
+//! The high-level API consists of two encoding functions
+//! [`encode_full_bytes`] and [`encode`]; and a decoding function
+//! [`decode`].
+//!
+//! [`encode_full_bytes`] is simple to use when you know that you have
+//! a whole number of bytes to encode and you want to produce a new
+//! String.  [`encode`] can handle numbers of bits that are not
+//! divisible by 8, and can also append to an existing String.
 //!
 //! Example:
 //!
 //! ```
-//! use libzbase32::{ZBase32Error, encode, decode};
+//! use libzbase32::{ZBase32Error, encode, encode_full_bytes, decode};
 //!
 //! # fn main() {
 //! const DATA: &'static [u8] = &[0, 44, 55, 128];
+//!
+//! let full_bytes_encoded = encode_full_bytes(DATA);
+//! assert_eq!(&full_bytes_encoded, "yysdxyy");
 //!
 //! let mut encoded = String::new();
 //! encode(DATA, &mut encoded, 25).expect("Encoding failed!");


### PR DESCRIPTION
There are many circumstances where all parties involved know that the unencoded form will itself be an integer number of octets (that is, that the length of the output bitstream should be a multiple of 8).  The current high level API is a bit clumsy for those use cases.

This series adds an even higher-level API that is simple to use in those scenarios.  It is a bit asymmetrical, in that the encoding has no error state (all bytestreams are valid input), while decoding does, since there are characters that should never be in z-base-32 (so some charstreams are invalid input).

This should close #1.

Note that it is an expanded API, but it is all entirely backward compatible with previous API.  So it probably warrants a minor version bump.