### PR TITLE
decoding: treat mis-transcribed z or o (2 or 0) generously.

### DIFF
--- a/src/decode_impl.rs
+++ b/src/decode_impl.rs
@@ -270,6 +270,14 @@ mod tests {
             buffer.clear();
             decode(test.encoded, &mut buffer, test.bits).unwrap();
             assert_eq!(&buffer[..], test.unencoded);
+            buffer = Vec::new();
+            decode(test.encoded.replace("z", "2").as_str(), &mut buffer, test.bits).unwrap();
+            assert_eq!(&buffer[..], test.unencoded,
+                       "failed to decode when 2 replaces z: {} (got: {:?})", test.encoded, buffer);
+            buffer = Vec::new();
+            decode(test.encoded.replace("o", "0").as_str(), &mut buffer, test.bits).unwrap();
+            assert_eq!(&buffer[..], test.unencoded,
+                       "failed to decode when 0 replaces o: {} (got: {:?})", test.encoded, buffer);
         }
     }
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,9 +1,11 @@
 // Maps from character code to their value in the z-base-32 scheme
-// Table starts from character code 49 ('1')
-pub const CHARACTER_MIN_VALUE: u8 = 49;
+// Table starts from character code 48 ('0')
+pub const CHARACTER_MIN_VALUE: u8 = 48;
 pub const CHARACTER_TO_QUINTET: &'static [u8] = &[
+    16, // '0' (misread of 'O')
     18, // '1'
-    255, 25, // '3'
+    23, // '2' (misread of 'Z')
+    25, // '3'
     26, // '4'
     27, // '5'
     30, // '6'


### PR DESCRIPTION
Closes: #4